### PR TITLE
faucet: catch invalid usernames before passign to eosjs

### DIFF
--- a/lib/moonbeam.js
+++ b/lib/moonbeam.js
@@ -8,6 +8,7 @@ const Joi = require('joi')
 const async = require('async')
 const uuid = require('uuid/v4')
 const dfns = require('date-fns')
+const isValidAccount = require('eos-name-verify')
 
 const Sunbeam = require('sunbeam')
 const Eos = require('eosjs')
@@ -208,7 +209,7 @@ class Moonbeam {
     const fc = this.conf.faucet
     const user = req.body.user
 
-    if (!user || !user.length || user.length !== 12) {
+    if (!isValidAccount(user)) {
       return res.status(500).json({ error: 'ERR_INVALID_USERNAME' })
     }
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "async": "^2.6.1",
     "cors": "^2.8.5",
     "date-fns": "^1.30.1",
+    "eos-name-verify": "git+https://github.com/bitfinexcom/eos-name-verify.git",
     "eosjs": "^16.0.9",
     "express": "^4.16.4",
     "helmet": "^3.14.0",


### PR DESCRIPTION
eojs@16.x will throw a unhandled promise rejection which we
can't catch on invalid usernames. this guards against invalid
 usernames