### PR TITLE
faucet: make facet init completely optional

### DIFF
--- a/lib/moonbeam.js
+++ b/lib/moonbeam.js
@@ -66,6 +66,10 @@ class Moonbeam {
     this.ws.setMaxListeners(500)
 
     const fc = this.conf.faucet
+    if (!fc) {
+      return
+    }
+
     const signatureProvider = new JsSignatureProvider(fc.keyProvider)
     const rpc = new JsonRpc(fc.httpEndpoint, { fetch })
     const api = new Api({
@@ -179,7 +183,10 @@ class Moonbeam {
 
     app.get('/time', cmw, this.onTimeHttpRequest.bind(this))
 
-    app.post('/faucet', cmw, this.onFaucetRequest.bind(this))
+    const fc = this.conf.faucet
+    if (fc) {
+      app.post('/faucet', cmw, this.onFaucetRequest.bind(this))
+    }
   }
 
   isTimeFrameSupported (f) {


### PR DESCRIPTION
right now you can leave the faucet conf empty, but class instances
are still created. this patch disables the faucet code completely in
case the faucet section is completely removed in the config