### PR TITLE
[WIP] forward transactions to the mainnet

### DIFF
--- a/example.js
+++ b/example.js
@@ -48,7 +48,8 @@ const req = getReq(port)
 })()
 
 ;(async () => {
-  // mainchain verify
+  // mainchain verify and fwd tx
+  const expireInSeconds = 30
   const user = 'testuser1111'
   const client = getClient(config)
 
@@ -69,7 +70,7 @@ const req = getReq(port)
   const tx = await client.api.transact(txdata, {
     broadcast: false,
     blocksBehind: 3,
-    expireSeconds: 10
+    expireSeconds: expireInSeconds
   })
 
   tx.serializedTransaction = eos.Serialize.arrayToHex(tx.serializedTransaction)
@@ -82,6 +83,7 @@ const req = getReq(port)
 
   console.log(await req('POST', '/sm-tos', payload))
   console.log(await req('POST', '/gm-tos', payload))
+  console.log(await req('POST', '/push-tx', payload))
 })()
 
 ;(async () => {

--- a/lib/moonbeam.js
+++ b/lib/moonbeam.js
@@ -120,6 +120,7 @@ class Moonbeam {
     app.post('/sm-tos', cmw, privRoutes.onPrivateTosMainSetHttpRequest.bind(privRoutes))
     app.post('/gm-tos', cmw, privRoutes.onPrivateTosMainGetHttpRequest.bind(privRoutes))
     app.post('/login', cmw, privRoutes.onPrivateLoginHttpRequest.bind(privRoutes))
+    app.post('/push-tx', cmw, privRoutes.onPrivatePushTxHttpRequest.bind(privRoutes))
 
     // https://api.bitfinex.com/v2/candles/trade:1m:tBTCUSD/last
     app.get('/v2/candles/:type/last', cmw, pubRoutes.onCandlesLastHttpRequest.bind(pubRoutes))

--- a/lib/routes-priv.js
+++ b/lib/routes-priv.js
@@ -431,6 +431,50 @@ class RoutesPriv {
     })
   }
 
+  async onPrivatePushTxHttpRequest (req, res) {
+    const rpc = this.mainnetRpc
+
+    const payload = req.body
+    const _v = Joi.validate(payload, schemaMainTx)
+
+    if (_v.error) {
+      log(_v.error)
+      return res.status(400).json({ error: 'ERR_INVALID_PAYLOAD' })
+    }
+
+    const { t } = payload
+
+    let txRes
+    try {
+      t.serializedTransaction = eosjs.Serialize.hexToUint8Array(t.serializedTransaction)
+      txRes = await rpc.push_transaction(t)
+    } catch (e) {
+      log(e, txRes)
+
+      if (e.json && e.json.error && e.json.error.code === 3080004) {
+        return res.status(400).json({ error: 'ERR_CPU', message: e.message })
+      }
+
+      return res.status(400).json({ error: 'ERR_TX_INVALID' })
+    }
+
+    if (!txRes.transaction_id || !txRes.processed) {
+      return res.status(403).json({ error: 'ERR_INVALID_KEY' })
+    }
+
+    const trace = txRes.processed.action_traces[0]
+
+    let user, permission
+    try {
+      user = trace.act.authorization[0].actor
+      permission = trace.act.authorization[0].permission
+    } catch (e) {
+      return res.status(403).json({ error: 'ERR_INVALID_KEY' })
+    }
+
+    res.status(200).json({ user, permission })
+  }
+
   verify (reqId, payload, cb) {
     this.ws
       .verifyTx(payload.meta, reqId, this.websocketOpts)

--- a/lib/routes-priv.js
+++ b/lib/routes-priv.js
@@ -20,7 +20,7 @@ const schemaMainTx = {
   v: Joi.number().required(),
   t: Joi.object({
     serializedTransaction: Joi.string().required(),
-    signatures: Joi.array().required().items(Joi.string()).single()
+    signatures: Joi.array().required().items(Joi.string())
   }).required(),
   code: Joi.string()
 }
@@ -455,7 +455,11 @@ class RoutesPriv {
         return res.status(400).json({ error: 'ERR_CPU', message: e.message })
       }
 
-      return res.status(400).json({ error: 'ERR_TX_INVALID' })
+      const resObj = { error: 'ERR_TX_INVALID' }
+      if (e.message) {
+        resObj.message = e.message
+      }
+      return res.status(400).json(resObj)
     }
 
     if (!txRes.transaction_id || !txRes.processed) {


### PR DESCRIPTION
Minimal example.js to verify `push-tx` endpoint:
```
'use strict'

const eos = require('eosjs')

const { port } = require('./config/moonbeam.conf.json')
const { getReq } = require('./test/helper')

const config = require('./config/dev-signing-ws.config.json')
const { getClient } = require('./dev-tools')

const req = getReq(port)

;(async () => {
  // mainchain verify and fwd tx
  const expireInSeconds = 35
  const user = 'testuser4321'
  const client = getClient(config)

  const txdata = {
    actions: [{
      account: 'testfaucet11',
      name: 'verify',
      authorization: [{
        actor: user,
        permission: 'active'
      }],
      data: {
        account: user
      }
    }]
  }

  const tx = await client.api.transact(txdata, {
    broadcast: false,
    blocksBehind: 3,
    expireSeconds: expireInSeconds
  })

  tx.serializedTransaction = eos.Serialize.arrayToHex(tx.serializedTransaction)

  const payload = {
    t: tx,
    v: 1,
    code: 'TEST12'
  }

  console.log(await req('POST', '/push-tx', payload))
})()
```