### PR TITLE
added cosign for other transactions; added per-user staking limits

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -31,6 +31,6 @@ module.exports = {
   dbUsers: {
     dbName: 'trades',
     mongoUrl: 'mongodb://localhost',
-    collectionTrades: 'priv_trades'
+    collectionHistory: 'priv_history'
   }
 }

--- a/config/development.js.example
+++ b/config/development.js.example
@@ -6,9 +6,16 @@ module.exports = {
   contract: '__DEV_CONTRACT__',
 
   cosign: {
-    pKey: '__DEV_COSIGN_KEY__',
-    contract: '__CONTRACT__',
-    permission: '__PERMISSION__'
+    duelAuth: {
+      contract: '__CONTRACT__',
+      permission: '__PERMISSION__',
+      pKey: '__DEV_COSIGN_KEY__'
+    },
+    duelActions: {
+      contract: '__CONTRACT__',
+      permission: '__PERMISSION__',
+      pKey: '__DEV_COSIGN_KEY__'
+    }
   },
 
   hcaptcha: {
@@ -19,6 +26,6 @@ module.exports = {
   dbUsers: {
     dbName: 'trades',
     mongoUrl: 'mongodb://localhost:27017',
-    collectionTrades: 'priv_trades'
+    collectionHistory: 'priv_history'
   }
 }

--- a/lib/helpers/db.js
+++ b/lib/helpers/db.js
@@ -12,7 +12,7 @@ exports.start = () =>
   new Promise((resolve, reject) => {
     db.start(err => {
       if (err) return reject(err)
-      collections.trades = db.db.collection(dbUsers.collectionTrades)
+      collections.trades = db.db.collection(dbUsers.collectionHistory)
       resolve()
     })
   })

--- a/lib/helpers/grenache.js
+++ b/lib/helpers/grenache.js
@@ -26,6 +26,7 @@ module.exports = {
   tradingCompetitionRequest: getServiceRequest('rest:eosfinex:tradingcompetition'),
   affiliatesRequest: getServiceRequest('rest:core:affiliate'),
   userSettingsRequest: getServiceRequest('rest:core:user:settings'),
+  userRequest: getServiceRequest('rest:core:user'),
   start,
   stop
 }

--- a/lib/helpers/middlewares.js
+++ b/lib/helpers/middlewares.js
@@ -110,18 +110,50 @@ exports.verifyCaptcha = async (req, res, next) => {
 
 exports.verifyReguserTx = (req, res, next) => {
   const { tx: { t } } = req.body.data
-  const supportedActions = ['reguser']
+  const { contract: cosignContract, permission: cosignPermission } = cosign.duelAuth
 
-  const vRes = parseAndVerifyTx(t, supportedActions)
+  const vRes = parseAndVerifyTx(t)
   if (vRes.error) {
     return next(new BadRequestError('Reguser transaction validation failed', vRes))
   }
 
   const { txData } = vRes
+
+  if (txData.txObj.actions.length > 1) {
+    return next(new BadRequestError('Reguser transaction validation failed', {
+      error: 'ERR_TX_INVALID',
+      details: ['Wrong amount of actions']
+    }))
+  }
+
   const [action] = txData.txObj.actions
+  const perms = ['active', 'owner']
+
+  if (action.name !== 'reguser') {
+    return next(new BadRequestError('Reguser transaction validation failed', {
+      error: 'ERR_TX_INVALID',
+      details: ['Wrong action name']
+    }))
+  }
+
+  if (action.account !== contract) {
+    return next(new BadRequestError('Reguser transaction validation failed', {
+      error: 'ERR_TX_INVALID',
+      details: ['Wrong action account']
+    }))
+  }
+
+  const correctPermissions = perms.includes(action.authorization[action.authorization.length - 1].permission)
+  if (!correctPermissions) {
+    return next(new BadRequestError('Reguser transaction validation failed', {
+      error: 'ERR_TX_INVALID',
+      details: ['Wrong permissions']
+    }))
+  }
+
   const invalidAuth = action.authorization.length !== 2 ||
-    action.authorization[0].actor !== cosign.contract ||
-    action.authorization[0].permission !== cosign.permission ||
+    action.authorization[0].actor !== cosignContract ||
+    action.authorization[0].permission !== cosignPermission ||
     !isValidAccount(action.authorization[1].actor)
 
   if (invalidAuth) {
@@ -139,24 +171,86 @@ exports.verifyReguserTx = (req, res, next) => {
 }
 
 exports.verifyPushTx = (req, res, next) => {
+  const allowedActions = ['usertos', 'transfer', 'withdraw']
   const { t } = req.body.data
-  const supportedActions = ['transfer', 'withdraw', 'usertos']
+  const { contract: cosignContract, permission: cosignPermission } = cosign.duelActions
 
-  const vRes = parseAndVerifyTx(t, supportedActions)
+  const vRes = parseAndVerifyTx(t)
   if (vRes.error) {
     return next(new BadRequestError('Pushtx transaction validation failed', vRes))
   }
 
   const { txData } = vRes
-  const [action] = txData.txObj.actions
-  const invalidAuth = action.authorization.length !== 1 ||
-    !isValidAccount(action.authorization[0].actor)
 
-  if (invalidAuth) {
+  if (txData.txObj.actions.length < 2) {
     return next(new BadRequestError('Pushtx transaction validation failed', {
       error: 'ERR_TX_INVALID',
-      details: ['Wrong authorization']
+      details: ['Wrong amount of actions']
     }))
+  }
+
+  const [firstAction, ...restActions] = txData.txObj.actions
+
+  const firstActionIsValid = firstAction.name === 'validate' && firstAction.account === contract &&
+    firstAction.authorization[0].actor === cosignContract && firstAction.authorization[0].permission === cosignPermission
+
+  if (!firstActionIsValid) {
+    return next(new BadRequestError('Pushtx transaction validation failed', {
+      error: 'ERR_TX_INVALID',
+      details: ['Wrong first action']
+    }))
+  }
+
+  const { name: actionName } = restActions[0]
+
+  const isSameAction = restActions.every(({ name }) => name === actionName)
+  if (!isSameAction) {
+    return next(new BadRequestError('Pushtx transaction validation failed', {
+      error: 'ERR_TX_INVALID',
+      details: ['Different actions found']
+    }))
+  }
+
+  if (!allowedActions.includes(actionName)) {
+    return next(new BadRequestError('Pushtx transaction validation failed', {
+      error: 'ERR_TX_INVALID',
+      details: ['Wrong action name']
+    }))
+  }
+
+  if (restActions.length > 1 && !['transfer', 'withdraw'].includes(actionName)) {
+    return next(new BadRequestError('Pushtx transaction validation failed', {
+      error: 'ERR_TX_INVALID',
+      details: ['Wrong amount of actions']
+    }))
+  }
+
+  const perms = ['active', 'owner']
+  for (const action of restActions) {
+    if (actionName !== 'transfer' && action.account !== contract) {
+      return next(new BadRequestError('Pushtx transaction validation failed', {
+        error: 'ERR_TX_INVALID',
+        details: ['Wrong action account']
+      }))
+    }
+
+    const invalidAuth = action.authorization.length !== 1 ||
+      !isValidAccount(action.authorization[0].actor)
+
+    if (invalidAuth) {
+      return next(new BadRequestError('Pushtx transaction validation failed', {
+        error: 'ERR_TX_INVALID',
+        details: ['Wrong authorization']
+      }))
+    }
+
+    const correctPermissions = perms.includes(action.authorization[0].permission)
+    if (!correctPermissions) {
+      return next(new BadRequestError('Pushtx transaction validation failed', {
+        error: 'ERR_TX_INVALID',
+        details: ['Wrong permissions']
+      }))
+    }
   }
 
   req.body._validated = {

--- a/lib/helpers/tx-utils.js
+++ b/lib/helpers/tx-utils.js
@@ -14,7 +14,10 @@ const api = new Api({
 })
 
 const rpc = new JsonRpc(nodeHttpUrl, { fetch })
-const coSignatureProvider = new JsSignatureProvider([cosign.pKey])
+const coSignatureProviders = {
+  duelAuth: new JsSignatureProvider([cosign.duelAuth.pKey]),
+  duelActions: new JsSignatureProvider([cosign.duelActions.pKey])
+}
 
 exports.recoverPubKey = async ({ s, t }) => {
   const { chain_id: chainId } = await rpc.get_info()
@@ -52,7 +55,8 @@ exports.hexToObj = hexTx => {
   }
 }
 
-exports.coSign = async ({ serializedTransaction, signatures }) => {
+exports.coSign = async ({ serializedTransaction, signatures, cosignType = 'duelActions' }) => {
+  const coSignatureProvider = coSignatureProviders[cosignType]
   const [availableKeys, { chain_id: chainId }] = await Promise.all([
     coSignatureProvider.getAvailableKeys(),
     rpc.get_info()
@@ -84,7 +88,7 @@ exports.pushTx = async txData => {
   }
 }
 
-exports.parseAndVerifyTx = (txHex, supportedActions) => {
+exports.parseAndVerifyTx = txHex => {
   const result = {}
   let txData
   try {
@@ -94,36 +98,10 @@ exports.parseAndVerifyTx = (txHex, supportedActions) => {
     return { error: 'ERR_TX_INVALID', details: ['Wrong serialized transaction data'] }
   }
 
-  const perms = ['active', 'owner']
   const { txObj } = txData
-  const { actions, context_free_actions: cfa, transaction_extensions: tes } = txObj
-
+  const { context_free_actions: cfa, transaction_extensions: tes } = txObj
   if (cfa.length !== 0 || tes.length !== 0) {
     return { error: 'ERR_TX_INVALID', details: ['Wrong transaction data'] }
-  }
-
-  const { name: actionName } = actions[0]
-  const isSameAction = actions.every(({ name }) => name === actionName)
-  if (!isSameAction) {
-    return { error: 'ERR_TX_INVALID', details: ['Different actions found'] }
-  }
-
-  if (!supportedActions.includes(actionName)) {
-    return { error: 'ERR_TX_INVALID', details: ['Wrong action name'] }
-  }
-
-  if (actions.length > 1 && !['transfer', 'withdraw'].includes(actionName)) {
-    return { error: 'ERR_TX_INVALID', details: ['Wrong amount of actions'] }
-  }
-
-  for (const action of actions) {
-    if (actionName !== 'transfer' && action.account !== contract) {
-      return { error: 'ERR_TX_INVALID', details: ['Wrong action account'] }
-    }
-    const correctPermissions = perms.includes(action.authorization[action.authorization.length - 1].permission)
-    if (!correctPermissions) {
-      return { error: 'ERR_TX_INVALID', details: ['Wrong permissions'] }
-    }
   }
 
   return result

--- a/lib/routes/v1/index.js
+++ b/lib/routes/v1/index.js
@@ -58,9 +58,9 @@ router.post('/push-tx', getSchemaValidationMw(pushTransaction), verifyPushTx, as
   const result = await userRequest({ action: 'useStakeLimit', args: [{ account: user }] })
   if (!result.success) {
     if (result.message.startsWith('connect ECONNREFUSED') || result.message.startsWith('ERR_GRAPE_LOOKUP_EMPTY')) {
-      throw new GenericError(`grc initStakeLimit request failed: ${result.message}`)
+      throw new GenericError(`grc useStakeLimit request failed: ${result.message}`)
     }
-    throw new GenericError(`grc initStakeLimit request failed: ${result.message}`)
+    throw new BadRequestError(`Couldn't use stake limit: ${result.message}`, { error: 'ERR_STAKE_LIMIT' })
   }
 
   if (!result.data.allow) {
@@ -79,7 +79,7 @@ router.post('/push-tx', getSchemaValidationMw(pushTransaction), verifyPushTx, as
 
   res.status(200).json({
     ...txRes,
-    ...result.data
+    stakeLimits: result.data.data
   })
 }))
 
@@ -115,7 +115,7 @@ router.post('/register', getSchemaValidationMw(register), asyncMw(verifyCaptcha)
     if (result.message.startsWith('connect ECONNREFUSED') || result.message.startsWith('ERR_GRAPE_LOOKUP_EMPTY')) {
       throw new GenericError(`grc initStakeLimit request failed: ${result.message}`)
     }
-    throw new GenericError(`grc initStakeLimit request failed: ${result.message}`)
+    throw new BadRequestError(`Couldn't initialize stake limit: ${result.message}`, { error: 'ERR_STAKE_LIMIT' })
   }
 
   if (email) {
@@ -130,7 +130,7 @@ router.post('/register', getSchemaValidationMw(register), asyncMw(verifyCaptcha)
 
   res.status(200).json({
     ...txRes,
-    ...result
+    stakeLimits: result.data
   })
 }))
 
@@ -143,7 +143,7 @@ router.post('/stake-limits/get', getSchemaValidationMw(auth), checkAuth, asyncMw
     if (result.message.startsWith('connect ECONNREFUSED') || result.message.startsWith('ERR_GRAPE_LOOKUP_EMPTY')) {
       throw new GenericError(`grc getStakeLimit request failed: ${result.message}`)
     }
-    throw new GenericError(`grc getStakeLimit request failed: ${result.message}`)
+    throw new BadRequestError(`Couldn't get stake limit: ${result.message}`, { error: 'ERR_STAKE_LIMIT' })
   }
 
   res.status(200).json(result.data)

--- a/lib/routes/v1/index.js
+++ b/lib/routes/v1/index.js
@@ -7,7 +7,7 @@ const { tosCurrent, tosCurrentDate } = require('config')
 const { getSchemaValidationMw, checkAuth, verifyCaptcha, verifyReguserTx, verifyPushTx, asyncMw } = require('../../helpers/middlewares')
 const { coSign, pushTx, checkUserSignedTos } = require('../../helpers/tx-utils')
 const { register, pushTransaction, history, auth } = require('../../helpers/schemas')
-const { getAuthToken, affiliatesRequest, userSettingsRequest } = require('../../helpers/grenache')
+const { getAuthToken, affiliatesRequest, userSettingsRequest, userRequest } = require('../../helpers/grenache')
 const { ForbiddenError, GenericError, BadRequestError } = require('../../helpers/errors')
 const { getCollection } = require('../../helpers/db')
 
@@ -51,20 +51,36 @@ router.post('/login', getSchemaValidationMw(auth), checkAuth, asyncMw(async (req
 }))
 
 router.post('/push-tx', getSchemaValidationMw(pushTransaction), verifyPushTx, asyncMw(async (req, res) => {
-  const { txArr } = req.body._validated.pushTx
+  const { txArr, txObj } = req.body._validated.pushTx
   const { s } = req.body.data
+  const user = txObj.actions[1].authorization[0].actor
 
-  const pushTxData = {
+  const result = await userRequest({ action: 'useStakeLimit', args: [{ account: user }] })
+  if (!result.success) {
+    if (result.message.startsWith('connect ECONNREFUSED') || result.message.startsWith('ERR_GRAPE_LOOKUP_EMPTY')) {
+      throw new GenericError(`grc initStakeLimit request failed: ${result.message}`)
+    }
+    throw new GenericError(`grc initStakeLimit request failed: ${result.message}`)
+  }
+
+  if (!result.data.allow) {
+    throw new ForbiddenError('Staking limit has been reached', { error: 'ERR_STAKING_LIMIT_REACHED' })
+  }
+
+  const pushTxData = await coSign({
     serializedTransaction: txArr,
     signatures: [s]
-  }
+  })
 
   const txRes = await pushTx(pushTxData)
   if (txRes.error) {
     throw new GenericError('Failed to push transaction', txRes)
   }
 
-  res.status(200).json(txRes)
+  res.status(200).json({
+    ...txRes,
+    ...result.data
+  })
 }))
 
 router.post('/register', getSchemaValidationMw(register), asyncMw(verifyCaptcha), verifyReguserTx, asyncMw(async (req, res) => {
@@ -85,12 +101,21 @@ router.post('/register', getSchemaValidationMw(register), asyncMw(verifyCaptcha)
 
   const pushTxData = await coSign({
     serializedTransaction: txArr,
-    signatures: [tx.s]
+    signatures: [tx.s],
+    cosignType: 'duelAuth'
   })
 
   const txRes = await pushTx(pushTxData)
   if (txRes.error) {
     throw new GenericError('Failed to push reguser transaction', txRes)
+  }
+
+  const result = await userRequest({ action: 'initStakeLimit', args: [{ account: user }] })
+  if (!result.success) {
+    if (result.message.startsWith('connect ECONNREFUSED') || result.message.startsWith('ERR_GRAPE_LOOKUP_EMPTY')) {
+      throw new GenericError(`grc initStakeLimit request failed: ${result.message}`)
+    }
+    throw new GenericError(`grc initStakeLimit request failed: ${result.message}`)
   }
 
   if (email) {
@@ -103,7 +128,25 @@ router.post('/register', getSchemaValidationMw(register), asyncMw(verifyCaptcha)
     }
   }
 
-  res.status(200).json(txRes)
+  res.status(200).json({
+    ...txRes,
+    ...result
+  })
+}))
+
+router.post('/stake-limits/get', getSchemaValidationMw(auth), checkAuth, asyncMw(async (req, res) => {
+  const { txObj } = req.body._validated.authTx
+  const user = txObj.actions[0].authorization[0].actor
+
+  const result = await userRequest({ action: 'getStakeLimit', args: [{ account: user }] })
+  if (!result.success) {
+    if (result.message.startsWith('connect ECONNREFUSED') || result.message.startsWith('ERR_GRAPE_LOOKUP_EMPTY')) {
+      throw new GenericError(`grc getStakeLimit request failed: ${result.message}`)
+    }
+    throw new GenericError(`grc getStakeLimit request failed: ${result.message}`)
+  }
+
+  res.status(200).json(result.data)
 }))
 
 module.exports = router


### PR DESCRIPTION
Period for staking starts with the first staked transaction and lasts 24h, in which user is allowed to stake 3 transactions.
* `v1/stake-limits/get` authenticated endpoint added. Returns `{ totalAvailable: 3, used: 1, reset: 1589045587207 }` object. It also can return `{ totalAvailable: 3, used: 0 }` if the time period has reset but no staking has been done yet.
* `v1/register` now applies staking limit and is counted as a staked operation. The input payload remains the same but the response will now contain staking limits info
* `v1/push-tx` now requires the passed transaction to have at least 2 actions and in addition returns staking updated limits for the user. Second action (and others if it's `transfer` or `withdraw`) should be pretty much the same as it was. First one should `validate` with the following contents:
```
{
    account: <contract>,
    name: 'validate',
    authorization: [{
      actor: 'eosfinexstak',
      permission: 'active'
    }],
    data: {
      account: 'eosfinexstak'
    }
  }
```
See `example.js`